### PR TITLE
Improve layout

### DIFF
--- a/src/components/CheckBox.js
+++ b/src/components/CheckBox.js
@@ -5,7 +5,11 @@ import styled from 'styled-components'
 import { green, redf } from 'logger'
 
 const CheckBoxDiv = styled.div`
-  
+
+`
+
+const CheckBoxInput = styled.input`
+vertical-align: middle;
 `
 
 /*
@@ -25,10 +29,10 @@ export const CheckBox = ({
   onChange,
 }) => {
   return <CheckBoxDiv>
-    <input 
-      type="checkbox" 
-      name={name} 
-      checked={checked} 
+    <CheckBoxInput
+      type="checkbox"
+      name={name}
+      checked={checked}
       onChange={onChange}
     />
   </CheckBoxDiv>

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -45,7 +45,7 @@ export const DatePicker = React.memo(({ disabled, maxWidth, name, value }) => {
   }
 
   return (
-    <DatePickerDiv>
+    <DatePickerDiv className="mx-1">
       <DayPickerInput
         // disabled={disabled} TODO: not working
         inputProps={{

--- a/src/components/RenderCount.js
+++ b/src/components/RenderCount.js
@@ -8,7 +8,7 @@ import { green, yellow, red } from 'logger'
 // const RenderResult = ({ title, count }) => {
 //   const { actual, min, max } = count
 //   return (
-    
+
 //     <span>
 //       <span>{title}:</span> (<span>actual=<b>{actual}</b></span>, <span>min=<b>{min}</b></span>, <span>max=<b>{max}</b></span>)
 //     </span>
@@ -29,9 +29,9 @@ import { green, yellow, red } from 'logger'
 
 export const RenderCount = ({ componentName, countTotal = {}, countReturn = {} }) => {
   return (
-    <div>
+    <div className="my-1">
 
-      <span>{componentName} - </span><span>total: {countTotal.actual}</span><span>return: {countReturn.actual}</span>
+      <span>{componentName} - </span><span>total: {countTotal.actual}</span> <span>return: {countReturn.actual}</span>
     </div>
   )
 }
@@ -70,5 +70,5 @@ RenderCount.propTypes = {
     min: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired
   }).isRequired
-  
+
 }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -47,7 +47,7 @@ export const Select = ({
 }) => {
   const { errorLevelNone } = errorLevels
   return (
-    <div>
+    <div className="mx-1">
       <SelectControl
         className={classNames('custom-select', 'custom-select-sm')}
         disabled={disabled}

--- a/src/components/TextEdit/TextEdit.js
+++ b/src/components/TextEdit/TextEdit.js
@@ -42,7 +42,7 @@ export const TextEdit = React.memo(
     value = ''
   }) => {
     countTotal = countTotal + 1
-    
+
     countReturn = countReturn + 1
     return (
       <>
@@ -51,7 +51,7 @@ export const TextEdit = React.memo(
           countTotal={{ actual: countTotal, min: 4, max: 4 }}
           countReturn={{ actual: countReturn, min: 4, max: 4 }}
         />
-        <TextEditDiv>
+        <TextEditDiv className="mx-1">
           <InputLabel>{labelText}</InputLabel>
           <TextEditInput
             disabled={disabled}

--- a/src/components/TextEdit/TextEdit.js
+++ b/src/components/TextEdit/TextEdit.js
@@ -33,6 +33,7 @@ export const TextEdit = React.memo(
     disabled,
     errorLevel = errorLevelNone,
     labelText = '',
+    width,
     maxWidth,
     minChars = 0,
     name,
@@ -56,6 +57,7 @@ export const TextEdit = React.memo(
           <TextEditInput
             disabled={disabled}
             errorLevel={errorLevel}
+            width={width}
             maxWidth={maxWidth}
             name={name}
             onBlur={onBlur}
@@ -87,6 +89,7 @@ TextEdit.propTypes = {
     message: PropTypes.string.isRequired
   }),
   value: isValidInitialValue,
+  width: PropTypes.number,
   maxWidth: PropTypes.number,
   minChars: PropTypes.number,
   name: PropTypes.string.isRequired,

--- a/src/components/TextEdit/TextEditInput.js
+++ b/src/components/TextEdit/TextEditInput.js
@@ -14,6 +14,7 @@ let countTotal = 0
 let countReturn = 0
 
 const TextInput = styled.input`
+  width: ${(props) => props.width + 'px'};
   max-width: ${(props) =>
     props.maxWidth === 'none' ? 'none' : props.maxWidth + 'px'};
   background-color: ${({ errorLevel }) => errorLevel.color};
@@ -23,6 +24,7 @@ export const TextEditInput = ({
   disabled,
   errorLevel,
   value,
+  width,
   maxWidth = 'none',
   name,
   onBlur,
@@ -46,6 +48,7 @@ export const TextEditInput = ({
         className={classNames(['form-control', 'form-control-sm'])}
         disabled={disabled}
         errorLevel={errorLevel}
+        width={width}
         maxWidth={maxWidth}
         name={name}
         onBlur={_handleBlur}

--- a/src/components/TextEditOrDatePicker.js
+++ b/src/components/TextEditOrDatePicker.js
@@ -20,6 +20,7 @@ export const TextEditOrDatePicker = ({
   errorLevel,
   field,
   value,
+  width,
   maxWidth,
   minChars,
   name,
@@ -46,10 +47,11 @@ export const TextEditOrDatePicker = ({
   }
   return (
     <>
-      
+
       <TextEdit
         disabled={disabled}
         errorLevel={errorLevel}
+        width={width}
         maxWidth={maxWidth}
         name={name}
         onBlur={onBlur}
@@ -75,6 +77,7 @@ TextEditOrDatePicker.propTypes = {
   }),
   field: PropTypes.oneOf(txFieldNames),
   value: PropTypes.any,
+  width: PropTypes.number,
   maxWidth: PropTypes.number,
   minChars: PropTypes.number,
   name: PropTypes.string.isRequired,

--- a/src/features/rules/Rule/Rule.js
+++ b/src/features/rules/Rule/Rule.js
@@ -15,6 +15,7 @@ import { selectRuleEdit } from 'features/selectors'
 /* eslint-disable */
 import { green, purple, red } from 'logger'
 import { RenderCount } from 'components/RenderCount'
+import { ContainerFluid } from 'components/ContainerFluid'
 /* eslint-enable */
 
 let countTotal = 0
@@ -48,7 +49,7 @@ export const Rule = () => {
 
   countReturn = countReturn + 1
   return (
-    <>
+    <ContainerFluid>
       <RenderCount
         componentName="Rule"
         countTotal={{ actual: countTotal, min: 8, max: 14 }}
@@ -62,6 +63,6 @@ export const Rule = () => {
       />
       <Criteria />
       <Actions />
-    </>
+    </ContainerFluid>
   )
 }

--- a/src/features/rules/actions/Actions.js
+++ b/src/features/rules/actions/Actions.js
@@ -47,6 +47,7 @@ export const Actions = () => {
                 key={_id}
                 actionId={_id}
                 minChars={3}
+                width={300}
                 maxWidth={10}
               />
             )

--- a/src/features/rules/actions/Actions.js
+++ b/src/features/rules/actions/Actions.js
@@ -30,15 +30,15 @@ export const Actions = () => {
 
   countReturn = countReturn + 1
   return (
-    <div>
-      <h4>Actions</h4>
+    <div className="mb-3">
+      <h4 className="mb-1">Actions</h4>
       <RenderCount
         componentName="Actions"
         countTotal={{ actual: countTotal, min: 2, max: 2 }}
         countReturn={{ actual: countReturn, min: 2, max: 2 }}
       />
 
-      <Wrapper>
+      <Wrapper className="my-1">
         {actions.map((a) => {
           const { _id, field, actionType } = a
           if (field === txFields.description.name) {

--- a/src/features/rules/actions/Categorize.js
+++ b/src/features/rules/actions/Categorize.js
@@ -20,7 +20,7 @@ export const Categorize = ({ action, minChars }) => {
     const newAction = R.mergeRight(_action, { [name]: value })
     _setAction(newAction)
     // if (eventType === 'blur') {
-      dispatch(ruleEditActionUpdate(newAction))
+    dispatch(ruleEditActionUpdate(newAction))
     // }
   }
 
@@ -31,6 +31,7 @@ export const Categorize = ({ action, minChars }) => {
         name={txFields.category1.name}
         labelText='Category 1'
         value={category1}
+        width={200}
         minChars={minChars}
         onBlur={_handleEvent}
         onChange={_handleEvent}
@@ -40,6 +41,7 @@ export const Categorize = ({ action, minChars }) => {
         name={txFields.category2.name}
         labelText='Category 2'
         value={category2}
+        width={200}
         minChars={minChars}
         onBlur={_handleEvent}
         onChange={_handleEvent}

--- a/src/features/rules/actions/RenameDescription.js
+++ b/src/features/rules/actions/RenameDescription.js
@@ -3,12 +3,18 @@ import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ruleEditActionUpdate } from 'features/rules'
 import * as R from 'ramda'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
 
 // eslint-disable-next-line
 import { purple, green, redf } from 'logger'
 import { selectRuleEditRenameAction } from 'features/selectors'
 
-export const RenameDescription = () => {
+const TextInput = styled.input`
+  width: ${(props) => props.width + 'px'};
+`
+
+export const RenameDescription = ({ width }) => {
 
   const [_action, _setAction] = useState(useSelector(selectRuleEditRenameAction))
   const { replaceWithValue, _id: actionId } = _action
@@ -23,9 +29,10 @@ export const RenameDescription = () => {
   }
 
   return (
-    <input
+    <TextInput
       key={actionId}
       className="mr-1"
+      width={width}
       type="text"
       value={replaceWithValue}
       name="replaceWithValue"
@@ -34,6 +41,11 @@ export const RenameDescription = () => {
       placeholder='hi'
     />
   )
+}
+
+
+RenameDescription.propTypes = {
+  width: PropTypes.number,
 }
 
 /*

--- a/src/features/rules/actions/RenameDescription.js
+++ b/src/features/rules/actions/RenameDescription.js
@@ -1,5 +1,5 @@
 
-import React, {useState } from 'react'
+import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ruleEditActionUpdate } from 'features/rules'
 import * as R from 'ramda'
@@ -25,6 +25,7 @@ export const RenameDescription = () => {
   return (
     <input
       key={actionId}
+      className="mr-1"
       type="text"
       value={replaceWithValue}
       name="replaceWithValue"

--- a/src/features/rules/criteria/Criteria.js
+++ b/src/features/rules/criteria/Criteria.js
@@ -14,7 +14,6 @@ let countReturn = 0
 
 const ButtonRow = styled.div`
   display: flex;
-  padding-bottom: 16px;
   align-items: center;
 `
 
@@ -31,7 +30,7 @@ export const Criteria = () => {
   countTotal = countTotal + 1
 
   const criteria = useSelector(selectRuleEditCriteria)
-  const _handleButtonClick = () => {}
+  const _handleButtonClick = () => { }
 
   if (!criteria) {
     return null
@@ -39,13 +38,13 @@ export const Criteria = () => {
 
   countReturn = countReturn + 1
   return (
-    <div id="Criteria">
+    <div id="Criteria" className="mb-3">
       <RenderCount
         componentName="Criteria"
         countTotal={{ actual: countTotal, min: 2, max: 2 }}
         countReturn={{ actual: countReturn, min: 2, max: 2 }}
       />
-      <ButtonRow id="Criteria.Row">
+      <ButtonRow id="Criteria.Row" className="my-1">
         <H4>Criteria</H4>
         <Btn onClick={_handleButtonClick}>Add</Btn>
         <Btn onClick={_handleButtonClick}>Reset</Btn>

--- a/src/features/rules/criteria/CriterionEdit.js
+++ b/src/features/rules/criteria/CriterionEdit.js
@@ -106,7 +106,7 @@ export const CriterionEdit = ({ criterion }) => {
         countTotal={{ actual: countTotal, min: 4, max: 4 }}
         countReturn={{ actual: countReturn, min: 4, max: 4 }}
       />
-      <Row>
+      <Row className="my-1">
         {/* <CheckDiv id='CheckDiv'> */}
         <CheckBox name="active" checked={active} onChange={_onChange} />
         <Select

--- a/src/features/rules/criteria/CriterionEdit.js
+++ b/src/features/rules/criteria/CriterionEdit.js
@@ -111,7 +111,7 @@ export const CriterionEdit = ({ criterion }) => {
         <CheckBox name="active" checked={active} onChange={_onChange} />
         <Select
           disabled={!active}
-          maxWidth={125}
+          maxWidth={130}
           name="field"
           onBlur={_onBlur}
           onChange={_onChange}
@@ -125,7 +125,7 @@ export const CriterionEdit = ({ criterion }) => {
         </Select>
         <Select
           disabled={!active}
-          maxWidth={125}
+          maxWidth={150}
           name="operation"
           onBlur={_onBlur}
           onChange={_onChange}
@@ -141,6 +141,7 @@ export const CriterionEdit = ({ criterion }) => {
           disabled={!active}
           field={field}
           value={value}
+          width={300}
           maxWidth={900}
           name="value"
           onChange={_onChange}


### PR DESCRIPTION
<img width="1280" alt="Screen Shot 2020-12-19 at 7 50 56 PM" src="https://user-images.githubusercontent.com/40745303/102702706-8827b100-4233-11eb-8b1d-d0ef32b00190.png">

Could potentially move the Actions text inputs to there own line in-order to give more room to make them larger and add labels.